### PR TITLE
[common]: move array length into a common helper

### DIFF
--- a/common/include/common/array.h
+++ b/common/include/common/array.h
@@ -1,0 +1,26 @@
+/**
+ * Looking Glass
+ * Copyright (C) 2017-2021 The Looking Glass Authors
+ * https://looking-glass.io
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+
+#ifndef _LG_ARRAY_H_
+#define _LG_ARRAY_H_
+
+#define ARRAY_LENGTH(arr) (sizeof(arr) / sizeof(*(arr)))
+
+#endif

--- a/host/platform/Windows/capture/DXGI/src/dxgi.c
+++ b/host/platform/Windows/capture/DXGI/src/dxgi.c
@@ -20,6 +20,7 @@
 
 #include "interface/capture.h"
 #include "interface/platform.h"
+#include "common/array.h"
 #include "common/debug.h"
 #include "common/windebug.h"
 #include "common/option.h"
@@ -715,14 +716,13 @@ static void computeFrameDamage(Texture * tex)
   // By default, damage the full frame.
   tex->damageRectsCount = 0;
 
-  const int maxDamageRectsCount =
-    sizeof(tex->damageRects) / sizeof(*tex->damageRects);
+  const int maxDamageRectsCount = ARRAY_LENGTH(tex->damageRects);
 
   // Compute dirty rectangles.
   RECT dirtyRects[maxDamageRectsCount];
   UINT dirtyRectsBufferSizeRequired;
   if (IDXGIOutputDuplication_GetFrameDirtyRects(this->dup,
-        sizeof(dirtyRects) / sizeof(*dirtyRects), dirtyRects,
+        ARRAY_LENGTH(dirtyRects), dirtyRects,
         &dirtyRectsBufferSizeRequired) != S_OK)
     return;
 
@@ -737,7 +737,7 @@ static void computeFrameDamage(Texture * tex)
   DXGI_OUTDUPL_MOVE_RECT moveRects[(maxDamageRectsCount - dirtyRectsCount) / 2];
   UINT moveRectsBufferSizeRequired;
   if (IDXGIOutputDuplication_GetFrameMoveRects(this->dup,
-        sizeof(moveRects) / sizeof(*moveRects), moveRects,
+        ARRAY_LENGTH(moveRects), moveRects,
         &moveRectsBufferSizeRequired) != S_OK)
     return;
 


### PR DESCRIPTION
Since it is more generally useful, and less cryptic this way.